### PR TITLE
chore(docker): update Alpine base image to 3.22 for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN ls -la lerian-mcp-memory-server && \
     ./lerian-mcp-memory-server --help || echo "Binary built successfully"
 
 # Stage 2: Production runtime
-FROM alpine:3.19
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
- Updated Alpine Linux from 3.19 to 3.22 (latest stable)
- Addresses multiple CVEs in base image dependencies
- Improves container security posture

This update resolves security vulnerabilities reported in GitHub code scanning related to base image components.